### PR TITLE
[FIX] fix _verfiy_signature method in controller

### DIFF
--- a/pingen/controllers/main.py
+++ b/pingen/controllers/main.py
@@ -18,8 +18,10 @@ class PingenController(http.Controller):
 
     def _verify_signature(self, request_content):
         webhook_signature = http.request.httprequest.headers.get("Signature")
-        companies = http.request.env["res.company"].sudo().search([("pingen_webhook_secret", "!=", False)])
+        companies = http.request.env["res.company"].sudo().search([])
         for company in companies:
+            if not company.pingen_webhook_secret:
+                continue
             secret_signature = hmac.new(company.pingen_webhook_secret.encode("utf-8"), request_content, hashlib.sha256).hexdigest()
             if webhook_signature == secret_signature:
                 return company


### PR DESCRIPTION
issue with webhooks after last release:

`response_wrap\n    response = f(*args, **kw)\n  File \"/odoo/external-src/report-print-send/pingen/controllers/main.py\", line 97, in sent_letters\n    self._verify_signature(request_content)\n  File \"/odoo/external-src/report-print-send/pingen/controllers/main.py\", line 23, in _verify_signature\n    secret_signature = hmac.new(company.pingen_webhook_secret.encode(\"utf-8\"), request_content, hashlib.sha256).hexdigest()\nAttributeError: 'bool' object has no attribute 'encode'", "uid": null, "request_id": "ce166822-036d-4cb5-b3d6-9525987c32f2"}`

```
>>> env["res.company"].sudo().search([("pingen_webhook_secret", "!=", False)])
{"asctime": "2023-05-10 07:44:53,482", "pid": 306, "levelname": "ERROR", "dbname": "empty_hill_2459", "name": "odoo.osv.expression", "message": "Non-stored field res.company.pingen_webhook_secret cannot be searched.", "uid": null, "request_id": null}
res.company(3, 1, 4)
```